### PR TITLE
Fix duplicate pane divider border

### DIFF
--- a/src/renderer/panes.ts
+++ b/src/renderer/panes.ts
@@ -230,9 +230,7 @@ export function renderPanes(refit = false): void {
         ? focusedAccent
         : pane.accent;
     const rightBorderColor =
-      layout.isFocused || index === state.panes.length - 1
-        ? pane.accent
-        : 'transparent';
+      index === state.panes.length - 1 ? pane.accent : 'transparent';
 
     node.root.classList.toggle('is-focused', layout.isFocused);
     node.root.classList.toggle(


### PR DESCRIPTION
## Summary
- stop drawing the focused pane right border on shared internal dividers
- keep the outer right edge border on the last pane only
- remove the ghost/double vertical divider line seen between panes

## Verification
- pnpm build
- pnpm capture
- verified the capture no longer shows duplicate divider lines between panes