### PR TITLE
chore: release v0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.10
+
+- Make wide layouts fill the full stage width when all panes can fit
+- Gate pane width expansion by stage capacity so narrower layouts keep their existing behavior
+- Remove the dedicated `pnpm capture` script and document `FLOWDECK_CAPTURE=1 pnpm start` instead
+
 ## v0.4.9
 
 - Fix duplicate/ghost vertical divider lines between panes by drawing each shared pane boundary only once

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowdeck",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump FlowDeck version from 0.4.9 to 0.4.10
- add changelog notes for the pane layout and capture workflow changes

## Test Plan
- pnpm build