### PR TITLE
Switch pane width from fixed pixels to responsive ratio

### DIFF
--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 export interface PersistedSettings {
   fontSize: number;
   paneOpacity: number;
-  paneWidth: number;
+  paneWidthRatio: number;
   defaultOpenDirectory: string;
   maxSessions: number;
   usageProvider: 'codex' | 'claude-code';
@@ -17,7 +17,7 @@ const SETTINGS_FILE = 'settings.json';
 const DEFAULTS: PersistedSettings = {
   fontSize: 14,
   paneOpacity: 0.75,
-  paneWidth: 720,
+  paneWidthRatio: 0.45,
   defaultOpenDirectory: app.getPath('home'),
   maxSessions: 8,
   usageProvider: 'codex',
@@ -27,9 +27,10 @@ const DEFAULTS: PersistedSettings = {
 const LIMITS = {
   fontSize: { min: 10, max: 24 },
   paneOpacity: { min: 0.5, max: 1 },
-  paneWidth: { min: 520, max: 1000 },
+  paneWidthRatio: { min: 0.22, max: 0.72 },
   maxSessions: { min: 1, max: 9 },
 } as const;
+const LEGACY_PANE_WIDTH_BASE = 1600;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
@@ -73,12 +74,15 @@ function sanitizePersistedSettings(parsed: unknown): PersistedSettings {
       LIMITS.paneOpacity.max,
       (v) => Number(v.toFixed(2)),
     ),
-    paneWidth: sanitizeSetting(
-      source.paneWidth,
-      DEFAULTS.paneWidth,
-      LIMITS.paneWidth.min,
-      LIMITS.paneWidth.max,
-      (v) => Math.round(v / 10) * 10,
+    paneWidthRatio: sanitizeSetting(
+      source.paneWidthRatio ??
+        (typeof source.paneWidth === 'number'
+          ? source.paneWidth / LEGACY_PANE_WIDTH_BASE
+          : undefined),
+      DEFAULTS.paneWidthRatio,
+      LIMITS.paneWidthRatio.min,
+      LIMITS.paneWidthRatio.max,
+      (v) => Number(v.toFixed(2)),
     ),
     defaultOpenDirectory,
     maxSessions: sanitizeSetting(

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -62,12 +62,12 @@
           </select>
 
           <label class="settings-row" for="pane-width-range">
-            <span>Pane width</span>
-            <span id="pane-width-value">720px</span>
+            <span>Pane width ratio</span>
+            <span id="pane-width-value">45%</span>
           </label>
           <div class="settings-dual">
-            <input id="pane-width-range" type="range" min="520" max="1000" step="10" value="720" />
-            <input class="settings-number" id="pane-width-input" type="number" min="520" max="1000" step="10" value="720" />
+            <input id="pane-width-range" type="range" min="22" max="72" step="1" value="45" />
+            <input class="settings-number" id="pane-width-input" type="number" min="22" max="72" step="1" value="45" />
           </div>
 
           <label class="settings-row" for="pane-opacity-range">

--- a/src/renderer/panes.ts
+++ b/src/renderer/panes.ts
@@ -34,6 +34,10 @@ interface PaneLayout {
   isFocused: boolean;
 }
 
+function getBasePaneWidth(stageWidth: number): number {
+  return Math.max(1, Math.round(stageWidth * state.settings.paneWidthRatio));
+}
+
 export function initPanes(paneCallbacks: PaneCallbacks): void {
   callbacks = paneCallbacks;
 }
@@ -42,7 +46,7 @@ export function initPanes(paneCallbacks: PaneCallbacks): void {
 
 function getPreviewWidth(stageWidth: number, count: number): number {
   if (count <= 1) return 0;
-  const baseWidth = state.settings.paneWidth;
+  const baseWidth = getBasePaneWidth(stageWidth);
   const focusedWidth = getFocusedPaneWidth();
   if (stageWidth >= baseWidth * count) {
     return stageWidth / count;
@@ -58,7 +62,7 @@ function getPaneLeft(
   previewWidth: number,
   focusedIndex: number,
 ): number {
-  const baseWidth = state.settings.paneWidth;
+  const baseWidth = getBasePaneWidth(dom.stage.clientWidth);
   const focusedWidth = getFocusedPaneWidth();
   if (previewWidth >= baseWidth) return index * previewWidth;
 
@@ -198,7 +202,7 @@ export function renderPanes(refit = false): void {
   const stageHeight = dom.stage.clientHeight;
   const isSinglePaneLayout = state.panes.length === 1;
   const canFillStageWidth =
-    stageWidth >= state.settings.paneWidth * state.panes.length;
+    stageWidth >= getBasePaneWidth(stageWidth) * state.panes.length;
   const previewWidth = getPreviewWidth(stageWidth, state.panes.length);
   const focusedIndex = getFocusedIndex();
   const focusedAccent =
@@ -214,7 +218,7 @@ export function renderPanes(refit = false): void {
         ? previewWidth
       : isFocused
         ? getFocusedPaneWidth()
-        : state.settings.paneWidth;
+        : getBasePaneWidth(stageWidth);
     const rawLeft = isSinglePaneLayout
       ? 0
       : getPaneLeft(index, previewWidth, focusedIndex);

--- a/src/renderer/settings-window.html
+++ b/src/renderer/settings-window.html
@@ -468,12 +468,12 @@
         <div class="section-body">
           <div class="row is-stacked">
             <div class="row-head">
-              <div class="row-label">Pane width</div>
-              <span class="row-value" id="pane-width-value">720px</span>
+              <div class="row-label">Pane width ratio</div>
+              <span class="row-value" id="pane-width-value">45%</span>
             </div>
             <div class="row-control is-full">
-              <input id="pane-width-range" type="range" min="520" max="1000" step="10" value="720" />
-              <input id="pane-width-input" type="number" min="520" max="1000" step="10" value="720" />
+              <input id="pane-width-range" type="range" min="22" max="72" step="1" value="45" />
+              <input id="pane-width-input" type="number" min="22" max="72" step="1" value="45" />
             </div>
           </div>
 
@@ -544,9 +544,10 @@
         els.defaultDirectoryInput.value = settings.defaultOpenDirectory;
         els.maxSessionsInput.value = String(settings.maxSessions);
         els.usageProviderInput.value = settings.usageProvider || 'codex';
-        els.paneWidthRange.value = String(settings.paneWidth);
-        els.paneWidthInput.value = String(settings.paneWidth);
-        els.paneWidthValue.textContent = settings.paneWidth + 'px';
+        const paneWidthPercent = Math.round(settings.paneWidthRatio * 100);
+        els.paneWidthRange.value = String(paneWidthPercent);
+        els.paneWidthInput.value = String(paneWidthPercent);
+        els.paneWidthValue.textContent = paneWidthPercent + '%';
         els.paneOpacityRange.value = settings.paneOpacity.toFixed(2);
         els.paneOpacityInput.value = settings.paneOpacity.toFixed(2);
         els.paneOpacityValue.textContent = settings.paneOpacity.toFixed(2);
@@ -614,7 +615,7 @@
           applyToInputs();
           return;
         }
-        settings.paneWidth = clamp(Math.round(v / 10) * 10, 520, 1000);
+        settings.paneWidthRatio = clamp(Math.round(v), 22, 72) / 100;
         applyToInputs();
         persist();
       }
@@ -638,13 +639,18 @@
         settings = saved || {
           fontSize: 14,
           paneOpacity: 0.75,
-          paneWidth: 720,
+          paneWidthRatio: 0.45,
           defaultOpenDirectory: bridge.defaultCwd,
           maxSessions: 8,
           usageProvider: 'codex',
           themeMode: 'system',
         };
         if (!settings.themeMode) settings.themeMode = 'system';
+        if (typeof settings.paneWidthRatio !== 'number') {
+          const legacyPaneWidth =
+            typeof settings.paneWidth === 'number' ? settings.paneWidth : 720;
+          settings.paneWidthRatio = clamp(Math.round((legacyPaneWidth / 1600) * 100), 22, 72) / 100;
+        }
         applyToInputs();
       });
 

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -37,6 +37,8 @@ export function applyThemeToDom(): void {
 export function applySettingsToDom(): void {
   const { settings } = state;
   const root = document.documentElement;
+  const paneWidthPx = Math.round(dom.stage.clientWidth * settings.paneWidthRatio);
+  const paneWidthPercent = Math.round(settings.paneWidthRatio * 100);
 
   applyThemeToDom();
 
@@ -46,14 +48,14 @@ export function applySettingsToDom(): void {
     '--pane-tone-opacity',
     getPaneToneOpacity(settings.paneOpacity).toFixed(2),
   );
-  root.style.setProperty('--pane-width', `${settings.paneWidth}px`);
+  root.style.setProperty('--pane-width', `${paneWidthPx}px`);
 
   dom.fontSizeInput.value = String(settings.fontSize);
   dom.defaultDirectoryInput.value = settings.defaultOpenDirectory;
   dom.maxSessionsInput.value = String(settings.maxSessions);
-  dom.paneWidthRange.value = String(settings.paneWidth);
-  dom.paneWidthInput.value = String(settings.paneWidth);
-  dom.paneWidthValue.textContent = `${settings.paneWidth}px`;
+  dom.paneWidthRange.value = String(paneWidthPercent);
+  dom.paneWidthInput.value = String(paneWidthPercent);
+  dom.paneWidthValue.textContent = `${paneWidthPercent}%`;
   dom.paneOpacityRange.value = settings.paneOpacity.toFixed(2);
   dom.paneOpacityInput.value = settings.paneOpacity.toFixed(2);
   dom.paneOpacityValue.textContent = settings.paneOpacity.toFixed(2);
@@ -110,7 +112,7 @@ function updateMaxSessions(value: string): void {
   persistSettings();
 }
 
-function updatePaneWidth(
+function updatePaneWidthRatio(
   value: string,
   render: (refit: boolean) => void,
 ): void {
@@ -119,9 +121,9 @@ function updatePaneWidth(
     applySettingsToDom();
     return;
   }
-  state.settings.paneWidth = Math.max(
-    520,
-    Math.min(1000, Math.round(parsed / 10) * 10),
+  state.settings.paneWidthRatio = Math.max(
+    0.22,
+    Math.min(0.72, Number((Math.round(parsed) / 100).toFixed(2))),
   );
   applySettingsToDom();
   persistSettings();
@@ -189,11 +191,11 @@ export function initSettingsListeners(
   });
 
   dom.paneWidthRange.addEventListener('input', () => {
-    updatePaneWidth(dom.paneWidthRange.value, render);
+    updatePaneWidthRatio(dom.paneWidthRange.value, render);
   });
 
   dom.paneWidthInput.addEventListener('change', () => {
-    updatePaneWidth(dom.paneWidthInput.value, render);
+    updatePaneWidthRatio(dom.paneWidthInput.value, render);
   });
 
   dom.paneOpacityRange.addEventListener('input', () => {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -27,7 +27,7 @@ export const ACCENT_PALETTE = [
 const DEFAULT_SETTINGS: AppSettings = {
   fontSize: 14,
   paneOpacity: 0.75,
-  paneWidth: 720,
+  paneWidthRatio: 0.45,
   defaultOpenDirectory: bridge.defaultCwd,
   maxSessions: 8,
   usageProvider: 'codex',
@@ -150,5 +150,5 @@ export function getResolvedTheme(): ResolvedTheme {
 }
 
 export function getFocusedPaneWidth(): number {
-  return state.transientPaneWidth ?? state.settings.paneWidth;
+  return state.transientPaneWidth ?? Math.round((dom.stage?.clientWidth ?? 1600) * state.settings.paneWidthRatio);
 }

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -93,7 +93,7 @@ export interface LifecycleDeps {
 export interface AppSettings {
   fontSize: number;
   paneOpacity: number;
-  paneWidth: number;
+  paneWidthRatio: number;
   defaultOpenDirectory: string;
   maxSessions: number;
   usageProvider: UsageProvider;


### PR DESCRIPTION
### Motivation

- Move pane sizing from an absolute pixel value to a responsive ratio so pane sizes scale with the stage/window width and behave consistently across different screen sizes.
- Preserve backwards compatibility by converting legacy pixel-based settings to the new ratio on load.

### Description

- Replace `paneWidth: number` with `paneWidthRatio: number` in persisted and in-memory settings and update the default from `720` to `0.45`.
- Add `LEGACY_PANE_WIDTH_BASE = 1600` and convert legacy `paneWidth` values to `paneWidthRatio` in `sanitizePersistedSettings` to maintain compatibility with old settings files.
- Change limits from absolute pixel bounds to ratio bounds (`0.22`–`0.72`) and update sanitizers/normalizers accordingly.
- Update renderer and settings UI: labels now show a percentage, range/number inputs use `22`–`72` (percent), handlers convert percent inputs to `paneWidthRatio`, and the CSS `--pane-width` var is computed from `stage.clientWidth * paneWidthRatio`.
- Update layout math and rendering to derive base widths from `paneWidthRatio` via `getBasePaneWidth(stageWidth)` and adjust functions that previously referenced `paneWidth` (e.g., `getPreviewWidth`, `getPaneLeft`, `renderPanes`, `getFocusedPaneWidth`).

### Testing

- Ran the project's automated test suite via `npm test` and the tests passed.
- Built the project with `npm run build` to ensure the TypeScript compilation succeeded and the bundle updated without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc90a13718832fafead101842001e4)