### PR TITLE
chore: release v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.11
+
+- Store pane width as a responsive ratio so session layouts scale more consistently across different window sizes
+- Preserve compatibility with older saved settings by converting legacy pixel-based pane width values on load
+- Upgrade GitHub Actions versions in CI and release workflows for newer runner compatibility
+
 ## v0.4.10
 
 - Make wide layouts fill the full stage width when all panes can fit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowdeck",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump FlowDeck version from 0.4.10 to 0.4.11
- add changelog notes for responsive pane width ratio support and CI/release workflow upgrades

## Test Plan
- pnpm build