### PR TITLE
Reduce reactivation stutter when returning to FlowDeck window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,6 +55,14 @@ interface TimestampedValue<T> {
   timestampMs: number;
 }
 
+interface UsageQuotaCacheEntry {
+  snapshot: UsageQuotaSnapshot;
+  loadedAtMs: number;
+}
+
+const USAGE_QUOTA_CACHE_TTL_MS = 15_000;
+const usageQuotaCache = new Map<UsageProvider, UsageQuotaCacheEntry>();
+
 function ensurePtyHelper(): void {
   if (process.platform !== 'darwin') return;
 
@@ -427,6 +435,12 @@ function emptyUsageQuota(provider: UsageProvider): UsageQuotaSnapshot {
 }
 
 function loadUsageQuotaSnapshot(provider: UsageProvider): UsageQuotaSnapshot {
+  const now = Date.now();
+  const cached = usageQuotaCache.get(provider);
+  if (cached && now - cached.loadedAtMs < USAGE_QUOTA_CACHE_TTL_MS) {
+    return cached.snapshot;
+  }
+
   const rootDirectory =
     provider === 'claude-code'
       ? path.join(app.getPath('home'), '.claude', 'projects')
@@ -443,9 +457,16 @@ function loadUsageQuotaSnapshot(provider: UsageProvider): UsageQuotaSnapshot {
     provider === 'codex' && usageRecord
       ? findLatestCodexSessionTotalTokens(rootDirectory)
       : null;
-  if (!usageRecord && !tokenUsage) return emptyUsageQuota(provider);
+  if (!usageRecord && !tokenUsage) {
+    const empty = emptyUsageQuota(provider);
+    usageQuotaCache.set(provider, {
+      snapshot: empty,
+      loadedAtMs: now,
+    });
+    return empty;
+  }
 
-  return {
+  const snapshot = {
     provider,
     sessionUsedPercent: usageRecord?.session.usedPercent ?? null,
     sessionResetsAt: usageRecord?.session.resetsAt ?? null,
@@ -459,6 +480,12 @@ function loadUsageQuotaSnapshot(provider: UsageProvider): UsageQuotaSnapshot {
         : tokenUsage?.totalTokens ?? null,
     queriedAt: new Date().toISOString(),
   };
+
+  usageQuotaCache.set(provider, {
+    snapshot,
+    loadedAtMs: now,
+  });
+  return snapshot;
 }
 
 function registerUsageQuotaHandlers(): void {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -25,11 +25,13 @@ import type { RenderFn, UsageProvider, UsageQuotaSnapshot } from './types';
 
 const USAGE_REFRESH_INTERVAL_MS = 10_000;
 const USAGE_EVENT_THROTTLE_MS = 4_000;
+const WINDOW_REACTIVATE_DEBOUNCE_MS = 250;
 let usageQuota: UsageQuotaSnapshot | null = null;
 let isRefreshingUsageQuota = false;
 let usageRefreshQueued = false;
 let usageRefreshTimer: number | null = null;
 let lastUsageRefreshStartedAt = 0;
+let lastWindowReactivateAt = 0;
 
 function createEmptyUsageQuota(provider: UsageProvider): UsageQuotaSnapshot {
   return {
@@ -422,15 +424,20 @@ export async function startApp(): Promise<void> {
   const refreshTimer = window.setInterval(() => {
     requestUsageQuotaRefresh();
   }, USAGE_REFRESH_INTERVAL_MS);
-  const handleWindowFocus = (): void => {
+  const handleWindowReactivated = (): void => {
+    const now = Date.now();
+    if (now - lastWindowReactivateAt < WINDOW_REACTIVATE_DEBOUNCE_MS) return;
+    lastWindowReactivateAt = now;
     requestUsageQuotaRefresh(true);
     focusActivePaneTerminal({ refit: true, forceBlur: true });
+  };
+  const handleWindowFocus = (): void => {
+    handleWindowReactivated();
   };
   window.addEventListener('focus', handleWindowFocus);
   const handleVisibilityChange = (): void => {
     if (document.visibilityState === 'visible') {
-      requestUsageQuotaRefresh(true);
-      focusActivePaneTerminal({ refit: true, forceBlur: true });
+      handleWindowReactivated();
     }
   };
   document.addEventListener('visibilitychange', handleVisibilityChange);


### PR DESCRIPTION
### Motivation
- Returning the app to the foreground could trigger both `focus` and `visibilitychange` handlers back-to-back causing duplicated work and observable input/scroll stutter.
- Loading usage quota performs synchronous filesystem traversal/parsing which is expensive when invoked repeatedly on rapid reactivation events.

### Description
- Added a short in-memory per-provider cache for usage quota snapshots in the main process with a `15_000ms` TTL and early cache return in `loadUsageQuotaSnapshot`, and cached empty snapshots to avoid repeated scans on missing data in `src/main/index.ts`.
- Coalesced renderer-side reactivation handling by introducing a debounced `handleWindowReactivated` and a `WINDOW_REACTIVATE_DEBOUNCE_MS = 250`ms guard so `focus` and `visibilitychange` now route to the same debounced path in `src/renderer/app.ts`.
- Ensured reactivation still triggers a forced terminal refit/focus and a usage quota refresh while preventing duplicate invocations.

### Testing
- Ran the build via `pnpm build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df02564980832fb9604738d7c5f787)