### PR TITLE
Add Linux release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/linux-artifact.yml
+++ b/.github/workflows/linux-artifact.yml
@@ -1,0 +1,42 @@
+name: Linux Artifact
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-linux-artifact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: pnpm/action-setup@v6.0.0
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Compile TypeScript (esbuild)
+        run: pnpm build
+
+      - name: Package Linux x64 artifacts
+        run: pnpm exec electron-builder --linux AppImage deb tar.gz --x64 --publish never
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: flowdeck-linux-x64
+          path: |
+            release/*.AppImage
+            release/*.deb
+            release/*.tar.gz
+            release/*.yml
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,45 @@ jobs:
           if-no-files-found: error
           retention-days: 5
 
+  # ── Phase 1c: build Ubuntu/Linux packages ──
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: pnpm/action-setup@v6.0.0
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Compile TypeScript (esbuild)
+        run: pnpm build
+
+      - name: Package with electron-builder
+        run: pnpm exec electron-builder --linux --publish never
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-linux
+          path: |
+            release/*.AppImage
+            release/*.deb
+            release/*.tar.gz
+            release/*.yml
+          if-no-files-found: error
+          retention-days: 5
+
   # ── Phase 2: collect artifacts and create a GitHub release ──
   publish:
-    needs: [build-macos, build-windows]
+    needs: [build-macos, build-windows, build-linux]
     runs-on: ubuntu-latest
 
     steps:
@@ -133,5 +169,8 @@ jobs:
             artifacts/*.dmg
             artifacts/*.zip
             artifacts/*.exe
+            artifacts/*.AppImage
+            artifacts/*.deb
+            artifacts/*.tar.gz
             artifacts/*.yml
             artifacts/app.asar

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Brand assets live in [`assets/brand/`](./assets/brand/). The icon features three
 - Minimal status bar that stays focused on the active working directory
 - Built-in update window with download progress, cancel, and restart actions
 - Capture mode that writes a static snapshot to `/tmp/flowdeck-prototype.png`
-- macOS/Windows packaging via `electron-builder`
+- macOS/Windows/Linux packaging via `electron-builder`
 
 ## Tech Stack
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,7 +40,7 @@ FlowDeck 当前面向 macOS 和 Windows。
 - 极简状态栏，专注显示当前活动窗格的工作目录
 - 内置更新窗口，支持下载进度、取消更新与重启安装
 - 支持截图模式，输出静态快照到 `/tmp/flowdeck-prototype.png`
-- 通过 `electron-builder` 进行 macOS / Windows 打包
+- 通过 `electron-builder` 进行 macOS / Windows / Linux 打包
 
 ## 技术栈
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,5 +37,15 @@ nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true
 
+# ── Linux ──
+linux:
+  icon: build/icon.png
+  category: Development
+  maintainer: zjy4fun
+  target:
+    - AppImage
+    - deb
+    - tar.gz
+
 publish:
   provider: github


### PR DESCRIPTION
## Summary
- Add electron-builder Linux targets for AppImage, deb, and tar.gz packages
- Add ubuntu-latest to CI build/type-check coverage
- Add a release workflow job that builds and uploads Linux artifacts to GitHub releases
- Update README platform packaging notes

## Test Plan
- pnpm build
- pnpm exec tsc --noEmit
- pnpm exec electron-builder --linux --dir --publish never
- Basic YAML indentation check for CI/release/electron-builder config