### PR TITLE
Update README release artifact docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,24 @@ Focus-first desktop terminal workspace for agentic coding, built with Electron, 
 
 FlowDeck is a desktop terminal workspace designed for focused, pane-based coding sessions. It combines a compact Electron shell with PTY-backed terminals so the UI stays lightweight while still running real shell sessions.
 
+## Download
+
+Download the latest release from [GitHub Releases](https://github.com/zjy4fun/FlowDeck/releases/latest).
+
+| Platform | Artifact | Notes |
+| --- | --- | --- |
+| macOS Apple Silicon | `.dmg`, `.zip` | Use the DMG for installation. See the macOS install notes below if Gatekeeper blocks the app. |
+| Windows x64 | `.exe` | Standard installer. |
+| Linux x64 | `.deb`, `.AppImage`, `.tar.gz` | Use `.deb` for Ubuntu/Debian, AppImage for portable use, or `.tar.gz` as a generic fallback. |
+
 ## Platform Support
 
-FlowDeck currently targets macOS and Windows.
+FlowDeck currently targets macOS, Windows, and Linux x64.
 
 - Local development and runtime validation are primarily done on macOS.
-- CI build and type-check validation run on macOS and Windows runners.
-- Release artifacts include macOS `.dmg` and `.zip`, plus Windows `.exe`.
-- Linux is not supported at this time.
+- CI build and type-check validation run on macOS, Windows, and Ubuntu runners.
+- Release artifacts include macOS `.dmg` and `.zip`, Windows `.exe`, and Linux `.deb`, `.AppImage`, and `.tar.gz`.
+- Linux packages are built on GitHub Actions `ubuntu-latest` for x64/amd64 systems.
 
 ## Brand
 
@@ -105,8 +115,13 @@ pnpm pack
 pnpm dist
 ```
 
-The current release workflow packages macOS and Windows artifacts.
-Linux artifacts are not produced.
+The current release workflow packages macOS, Windows, and Linux artifacts.
+
+Linux packages can also be built explicitly with:
+
+```bash
+pnpm exec electron-builder --linux AppImage deb tar.gz --x64 --publish never
+```
 
 ## Versioning and Releases
 
@@ -130,8 +145,8 @@ This does the following:
 
 After the tag reaches GitHub, the release workflow automatically:
 
-- builds macOS and Windows packages
-- uploads `.dmg`, `.zip`, `.exe`, `.yml`, and `app.asar` artifacts
+- builds macOS, Windows, and Linux packages
+- uploads `.dmg`, `.zip`, `.exe`, `.AppImage`, `.deb`, `.tar.gz`, `.yml`, and `app.asar` artifacts
 - creates a GitHub Release with the description from `CHANGELOG.md`
 
 ### Bump version only (dry run)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,14 +16,24 @@
 
 FlowDeck 是一个以专注、多窗格协作为核心的桌面终端工作区。它使用轻量的 Electron 外壳承载真实 PTY 终端会话，在保持界面紧凑的同时，提供可实际使用的 shell 体验。
 
+## 下载
+
+最新版本可在 [GitHub Releases](https://github.com/zjy4fun/FlowDeck/releases/latest) 下载。
+
+| 平台 | 产物 | 说明 |
+| --- | --- | --- |
+| macOS Apple Silicon | `.dmg`、`.zip` | 推荐使用 DMG 安装；如果被 Gatekeeper 拦截，可参考下方 macOS 安装说明。 |
+| Windows x64 | `.exe` | 标准安装包。 |
+| Linux x64 | `.deb`、`.AppImage`、`.tar.gz` | Ubuntu/Debian 推荐 `.deb`；免安装可用 AppImage；`.tar.gz` 可作为通用备用包。 |
+
 ## 平台支持
 
-FlowDeck 当前面向 macOS 和 Windows。
+FlowDeck 当前面向 macOS、Windows 和 Linux x64。
 
 - 本地开发与运行验证目前仍以 macOS 为主。
-- CI 构建与类型检查在 macOS 和 Windows runner 上执行。
-- 发版产物包含 macOS `.dmg`、`.zip`，以及 Windows `.exe`。
-- 暂不支持 Linux。
+- CI 构建与类型检查在 macOS、Windows 和 Ubuntu runner 上执行。
+- 发版产物包含 macOS `.dmg`、`.zip`，Windows `.exe`，以及 Linux `.deb`、`.AppImage`、`.tar.gz`。
+- Linux 安装包通过 GitHub Actions 的 `ubuntu-latest` 环境构建，面向 x64/amd64 系统。
 
 ## 品牌资源
 
@@ -105,8 +115,13 @@ pnpm pack
 pnpm dist
 ```
 
-当前发布流程会产出 macOS 与 Windows 安装包。
-暂不提供 Linux 产物。
+当前发布流程会产出 macOS、Windows 与 Linux 安装包。
+
+也可以显式构建 Linux 包：
+
+```bash
+pnpm exec electron-builder --linux AppImage deb tar.gz --x64 --publish never
+```
 
 ## 版本管理与发版
 
@@ -130,8 +145,8 @@ pnpm release
 
 当 tag 被推送到 GitHub 后，发布流水线会自动：
 
-- 构建 macOS 与 Windows 安装包
-- 上传 `.dmg`、`.zip`、`.exe`、`.yml` 与 `app.asar`
+- 构建 macOS、Windows 与 Linux 安装包
+- 上传 `.dmg`、`.zip`、`.exe`、`.AppImage`、`.deb`、`.tar.gz`、`.yml` 与 `app.asar`
 - 从 `CHANGELOG.md` 提取变更说明，创建 GitHub Release
 
 ### 仅更新版本号（预览）


### PR DESCRIPTION
## Summary
- add latest release download section to English and Chinese README files
- document Linux x64 artifacts alongside macOS and Windows
- update packaging and release workflow descriptions

## Test Plan
- README consistency check via Python script