### PR TITLE
Fix Linux fullscreen shortcuts and app icon

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -12,6 +12,10 @@ files:
   - dist/**/*
   - package.json
 
+extraResources:
+  - from: build/icon.png
+    to: build/icon.png
+
 asar: true
 
 # node-pty contains native binaries that cannot be loaded from asar.

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -52,6 +52,14 @@ await Promise.all([
     outfile: 'dist/test-support/window-lifecycle.cjs',
     format: 'cjs',
   }),
+  esbuild.build({
+    ...shared,
+    entryPoints: ['src/main/window-options.ts'],
+    platform: 'node',
+    target: 'node20',
+    outfile: 'dist/test-support/window-options.cjs',
+    format: 'cjs',
+  }),
 
   // Preload script
   esbuild.build({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ import {
   checkForUpdatesManual,
   registerUpdaterIpcHandlers,
 } from './updater';
+import { getWindowIconPath, shouldToggleFullScreenForInput } from './window-options';
 
 const isCaptureMode = process.env.FLOWDECK_CAPTURE === '1';
 
@@ -79,6 +80,7 @@ function openSettingsWindow(): void {
     (themeMode !== 'dark' && !nativeTheme.shouldUseDarkColors);
   const themeHash = resolvedLight ? 'light' : 'dark';
 
+  const icon = currentWindowIconPath();
   settingsWindow = new BrowserWindow({
     width: 560,
     height: 760,
@@ -87,8 +89,8 @@ function openSettingsWindow(): void {
     maximizable: false,
     backgroundColor: resolvedLight ? '#f1ede0' : '#1c1d22',
     title: 'Settings',
-    titleBarStyle: 'hiddenInset',
-    trafficLightPosition: { x: 14, y: 14 },
+    ...platformWindowChromeOptions(),
+    ...(icon ? { icon } : {}),
     show: false,
     webPreferences: {
       contextIsolation: true,
@@ -117,6 +119,45 @@ function sendToFocusedWindow(channel: string): void {
   if (win && !win.isDestroyed()) {
     win.webContents.send(channel);
   }
+}
+
+function currentWindowIconPath(): string | undefined {
+  return getWindowIconPath({
+    platform: process.platform,
+    appPath: app.getAppPath(),
+    resourcesPath: process.resourcesPath,
+    isPackaged: app.isPackaged,
+  });
+}
+
+function platformWindowChromeOptions(): Electron.BrowserWindowConstructorOptions {
+  if (process.platform !== 'darwin') return {};
+  return {
+    titleBarStyle: 'hiddenInset',
+    trafficLightPosition: { x: 12, y: 10 },
+  };
+}
+
+function registerFullScreenShortcuts(win: BrowserWindow): void {
+  win.webContents.on('before-input-event', (event, input) => {
+    if (
+      !shouldToggleFullScreenForInput({
+        platform: process.platform,
+        key: input.key,
+        isFullScreen: win.isFullScreen(),
+      })
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    if (input.key === 'Escape') {
+      win.setFullScreen(false);
+      return;
+    }
+
+    win.setFullScreen(!win.isFullScreen());
+  });
 }
 
 function confirmQuit(win?: BrowserWindow | null): boolean {
@@ -258,14 +299,15 @@ function buildAppMenu(): void {
 }
 
 function createWindow(): void {
+  const icon = currentWindowIconPath();
   const win = new BrowserWindow({
     width: 1600,
     height: 920,
     minWidth: 960,
     minHeight: 640,
     backgroundColor: '#111111',
-    titleBarStyle: 'hiddenInset',
-    trafficLightPosition: { x: 12, y: 10 },
+    ...platformWindowChromeOptions(),
+    ...(icon ? { icon } : {}),
     autoHideMenuBar: false,
     show: !isCaptureMode,
     webPreferences: {
@@ -285,6 +327,7 @@ function createWindow(): void {
   });
 
   win.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'));
+  registerFullScreenShortcuts(win);
 
   if (isCaptureMode) {
     win.webContents.once('did-finish-load', () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -9,6 +9,7 @@ import {
   shouldCloseWindowForAction,
   type UpdateWindowAction,
 } from './updater-logic';
+import { getWindowIconPath } from './window-options';
 
 const REPO = 'zjy4fun/FlowDeck';
 const ASAR_ASSET_NAME = 'app.asar';
@@ -749,6 +750,19 @@ function createUpdateWindow(): BrowserWindow {
   if (updateWindow && !updateWindow.isDestroyed()) return updateWindow;
 
   const initialSize = getUpdateWindowSize(updateWindowState);
+  const icon = getWindowIconPath({
+    platform: process.platform,
+    appPath: app.getAppPath(),
+    resourcesPath: process.resourcesPath,
+    isPackaged: app.isPackaged,
+  });
+  const macWindowChrome =
+    process.platform === 'darwin'
+      ? {
+          titleBarStyle: 'hiddenInset' as const,
+          trafficLightPosition: { x: 12, y: 12 },
+        }
+      : {};
   const win = new BrowserWindow({
     width: initialSize.width,
     height: initialSize.height,
@@ -757,8 +771,8 @@ function createUpdateWindow(): BrowserWindow {
     maximizable: false,
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#1e1e1e' : '#ececec',
     title: `Updating ${app.name}`,
-    titleBarStyle: 'hiddenInset',
-    trafficLightPosition: { x: 12, y: 12 },
+    ...macWindowChrome,
+    ...(icon ? { icon } : {}),
     show: false,
     webPreferences: {
       contextIsolation: true,

--- a/src/main/window-options.ts
+++ b/src/main/window-options.ts
@@ -1,0 +1,28 @@
+import * as path from 'path';
+
+export interface WindowIconPathOptions {
+  platform: NodeJS.Platform;
+  appPath: string;
+  resourcesPath: string;
+  isPackaged: boolean;
+}
+
+export interface FullScreenInputOptions {
+  platform: NodeJS.Platform;
+  key: string;
+  isFullScreen?: boolean;
+}
+
+export function getWindowIconPath(options: WindowIconPathOptions): string | undefined {
+  if (options.platform === 'darwin') return undefined;
+
+  const basePath = options.isPackaged ? options.resourcesPath : options.appPath;
+  return path.join(basePath, 'build', 'icon.png');
+}
+
+export function shouldToggleFullScreenForInput(options: FullScreenInputOptions): boolean {
+  if (options.platform === 'darwin') return false;
+  if (options.key === 'F11') return true;
+  if (options.key === 'Escape') return options.isFullScreen === true;
+  return false;
+}

--- a/tests/window-options.test.mjs
+++ b/tests/window-options.test.mjs
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  getWindowIconPath,
+  shouldToggleFullScreenForInput,
+} = require('../dist/test-support/window-options.cjs');
+
+test('Linux packaged windows use the extraResources app icon path', () => {
+  assert.equal(
+    getWindowIconPath({
+      platform: 'linux',
+      resourcesPath: '/opt/FlowDeck/resources',
+      appPath: '/opt/FlowDeck/resources/app.asar',
+      isPackaged: true,
+    }),
+    '/opt/FlowDeck/resources/build/icon.png',
+  );
+});
+
+test('Linux development windows use the repository icon path', () => {
+  assert.equal(
+    getWindowIconPath({
+      platform: 'linux',
+      resourcesPath: '/tmp/electron',
+      appPath: '/repo/FlowDeck',
+      isPackaged: false,
+    }),
+    '/repo/FlowDeck/build/icon.png',
+  );
+});
+
+test('macOS does not set a custom BrowserWindow icon', () => {
+  assert.equal(
+    getWindowIconPath({
+      platform: 'darwin',
+      resourcesPath: '/Applications/FlowDeck.app/Contents/Resources',
+      appPath: '/Applications/FlowDeck.app/Contents/Resources/app.asar',
+      isPackaged: true,
+    }),
+    undefined,
+  );
+});
+
+test('F11 toggles fullscreen on Linux and Windows', () => {
+  assert.equal(shouldToggleFullScreenForInput({ platform: 'linux', key: 'F11' }), true);
+  assert.equal(shouldToggleFullScreenForInput({ platform: 'win32', key: 'F11' }), true);
+});
+
+test('Escape exits fullscreen on Linux and Windows only when fullscreen is active', () => {
+  assert.equal(
+    shouldToggleFullScreenForInput({ platform: 'linux', key: 'Escape', isFullScreen: true }),
+    true,
+  );
+  assert.equal(
+    shouldToggleFullScreenForInput({ platform: 'linux', key: 'Escape', isFullScreen: false }),
+    false,
+  );
+});
+
+test('macOS keeps native fullscreen keyboard behavior', () => {
+  assert.equal(shouldToggleFullScreenForInput({ platform: 'darwin', key: 'F11' }), false);
+  assert.equal(
+    shouldToggleFullScreenForInput({ platform: 'darwin', key: 'Escape', isFullScreen: true }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- add Linux/Windows fullscreen keyboard handling so F11 toggles fullscreen and Escape exits when fullscreen is active
- set Linux/Windows BrowserWindow icons for main, settings, and update windows
- package `build/icon.png` as an extra resource so packaged Linux windows can load the app icon
- remove macOS-only hidden inset chrome options from non-macOS windows

## Root cause
- Linux windows did not install main-process fullscreen shortcuts, so terminal focus could leave users without a reliable way to exit fullscreen.
- The Linux package configured an installer icon, but the runtime BrowserWindow icon was never set and the PNG was not included in packaged app resources.

## Test Plan
- pnpm build
- node --test tests/window-options.test.mjs
- node --test tests/*.test.mjs
- pnpm exec tsc --noEmit
- pnpm exec electron-builder --linux --dir --publish never
- verified `release/linux-arm64-unpacked/resources/build/icon.png` exists locally