### PR TITLE
Fix terminal scrollback viewport scrolling

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -659,7 +659,8 @@ body.is-resizing-pane {
 }
 
 .terminal-host .xterm-viewport {
-  overflow: hidden !important;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
   background-color: var(--terminal-bg) !important;
 }
 

--- a/tests/terminal-scrollback-css.test.mjs
+++ b/tests/terminal-scrollback-css.test.mjs
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const styles = readFileSync(new URL('../src/renderer/styles.css', import.meta.url), 'utf8');
+
+test('terminal viewport remains vertically scrollable for scrollback history', () => {
+  const viewportRule = styles.match(/\.terminal-host \.xterm-viewport \{(?<body>[^}]+)\}/);
+
+  assert.ok(viewportRule, 'expected a terminal viewport CSS rule');
+  assert.match(viewportRule.groups.body, /overflow-y:\s*auto\s*!important;/);
+  assert.doesNotMatch(viewportRule.groups.body, /overflow:\s*hidden\s*!important;/);
+});


### PR DESCRIPTION
## Summary
- restore vertical scrolling on the xterm viewport so mouse-wheel scrollback can reveal previous output
- keep horizontal overflow hidden to avoid layout bleed
- add a regression test that prevents the viewport from being forced to `overflow: hidden` again

Fixes #27

## Verification
- corepack pnpm build
- node --test tests/*.test.mjs